### PR TITLE
pip-system-certs shall be default

### DIFF
--- a/bootstrap.Tests.ps1
+++ b/bootstrap.Tests.ps1
@@ -1,7 +1,7 @@
 $WebProxy = [net.webrequest]::defaultwebproxy
 
 BeforeAll {
-  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Variable i used in included script.')]
+  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Variable I used in included script.')]
   $TestExecution = $true
   . .\bootstrap.ps1
 }

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -106,7 +106,7 @@ Function Install-Scoop {
 Function Install-Python-Dependency {
     if ((Test-Path -Path 'requirements.txt') -or (Test-Path -Path 'Pipfile')) {
         # Prepare python environment
-        Invoke-CommandLine -CommandLine "python -m pip install pipenv"
+        Invoke-CommandLine -CommandLine "python -m pip install pipenv pip-system-certs"
         Edit-Env
         if ($clean) {
             # Start with a fresh virtual environment


### PR DESCRIPTION
This PR solves the long lasting issue that our company's self-signed certificates are working for all kind of Python package tools like pip, pipenv and flit.