### PR TITLE
fix: install scoop deps via bucket instead of URL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,6 @@
       "titleBar.inactiveBackground": "#ff3d0099",
       "titleBar.inactiveForeground": "#e7e7e799"
    },
-   "peacock.color": "#ff3d00"
+   "peacock.color": "#ff3d00",
+   "python-envs.defaultEnvManager": "ms-python.python:system"
 }

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ That's it! You're now ready to start developing your Python project using this r
 
   General Scoop settings:
   - scoop_installer = <https://raw.githubusercontent.com/xxthunder/ScoopInstall/v1.1.0/install.ps1>
-  - scoop_default_bucket_base_url = <https://raw.githubusercontent.com/ScoopInstaller/Main/master/bucket>
-  - scoop_python_bucket_base_url = <https://raw.githubusercontent.com/ScoopInstaller/Versions/master/bucket>
+  - scoop_default_bucket_base_url = *(empty by default)* — if set, dependencies (7zip, lessmsi, etc.) are installed from this raw URL instead of the Scoop main bucket
+  - scoop_python_bucket_base_url = *(empty by default)* — if set, Python is installed from this raw URL instead of the Scoop versions bucket
 
   Scoop configuration:
   - autostash_on_conflict = true

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -10,8 +10,8 @@ function Get-BootstrapConfig {
         python_package_manager        = "poetry"
         scoop_installer               = "https://raw.githubusercontent.com/avengineers/ScoopInstall/refs/tags/v1.1.0/install.ps1"
         scoop_installer_with_repo_arg = $false
-        scoop_default_bucket_base_url = "https://raw.githubusercontent.com/ScoopInstaller/Main/master/bucket"
-        scoop_python_bucket_base_url  = "https://raw.githubusercontent.com/ScoopInstaller/Versions/master/bucket"
+        scoop_default_bucket_base_url = ""
+        scoop_python_bucket_base_url  = ""
         scoop_ignore_scoopfile        = $false
         scoop_config                  = @{
             autostash_on_conflict = "true"
@@ -76,18 +76,24 @@ function Install-Scoop {
         Invoke-CommandLine ("scoop config " + $item.Key + " " + $item.Value) -Silent $true -PrintCommand $false
     }
 
-    # Install any installer dependencies
+    # Install scoop dependencies.
     # CAUTION: the order is important and shall not be changed!
     # - 7zip needs lessmsi for installation
     # - innounp needs 7zip
-    $manifests = @(
-        "lessmsi.json",
-        "7zip.json",
-        "innounp.json",
-        "dark.json"
-    )
-    $manifests | ForEach-Object {
-        Invoke-CommandLine "scoop install $($config.scoop_default_bucket_base_url)/$_" -Silent $true -PrintCommand $false
+    if ($config.scoop_default_bucket_base_url) {
+        # Legacy mode: install from raw URL (for repos that override this config)
+        $manifests = @("lessmsi.json", "7zip.json", "innounp.json", "dark.json")
+        $manifests | ForEach-Object {
+            Invoke-CommandLine "scoop install $($config.scoop_default_bucket_base_url)/$_" -Silent $true -PrintCommand $false
+        }
+    }
+    else {
+        # Default: add main bucket and install by name (avoids post_install script issues)
+        Invoke-CommandLine "scoop bucket add main" -Silent $false -PrintCommand $false -StopAtError $false
+        $dependencies = @("lessmsi", "7zip", "innounp", "dark")
+        $dependencies | ForEach-Object {
+            Invoke-CommandLine "scoop install $_" -Silent $true -PrintCommand $false
+        }
     }
 
     # Import scoopfile.json
@@ -121,8 +127,15 @@ function Install-Python {
     $pythonPath = (Get-Command $python -ErrorAction SilentlyContinue).Source
     if ($null -eq $pythonPath) {
         Write-Output "$python not found. Try to install $python via scoop ..."
-        # Install python
-        Invoke-CommandLine "scoop install $($config.scoop_python_bucket_base_url)/$python.json"
+        if ($config.scoop_python_bucket_base_url) {
+            # Legacy mode: install from raw URL
+            Invoke-CommandLine "scoop install $($config.scoop_python_bucket_base_url)/$python.json"
+        }
+        else {
+            # Default: add versions bucket and install by name
+            Invoke-CommandLine "scoop bucket add versions" -Silent $false -PrintCommand $false -StopAtError $false
+            Invoke-CommandLine "scoop install $python"
+        }
 
         Initialize-EnvPath
     }

--- a/tests/bootstrap.Tests.ps1
+++ b/tests/bootstrap.Tests.ps1
@@ -109,7 +109,7 @@ Describe "Install-Scoop" {
 
         Install-Scoop
 
-        Should -Invoke -CommandName Invoke-CommandLine -Exactly 8
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 9
         Should -Invoke -CommandName Invoke-CommandLine -Exactly 4 -ParameterFilter { $CommandLine -like "scoop config *" }
         Should -Invoke -CommandName Invoke-CommandLine -Exactly 1 -ParameterFilter { $CommandLine -eq "scoop config use_lessmsi true" }
     }
@@ -120,7 +120,21 @@ Describe "Install-Scoop" {
 
         Install-Scoop
 
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 9
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 1 -ParameterFilter { $CommandLine -eq "scoop bucket add main" }
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 4 -ParameterFilter { $CommandLine -match "^scoop install (lessmsi|7zip|innounp|dark)$" }
+    }
+
+    It "shall install scoop dependencies from URL when scoop_default_bucket_base_url is configured" {
+        Mock -CommandName Get-Command -MockWith { $true }
+        Mock -CommandName Test-Path -MockWith { $false }
+
+        $config.scoop_default_bucket_base_url = "https://raw.githubusercontent.com/ScoopInstaller/Main/master/bucket"
+        Install-Scoop
+        $config.scoop_default_bucket_base_url = ""
+
         Should -Invoke -CommandName Invoke-CommandLine -Exactly 8
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 0 -ParameterFilter { $CommandLine -eq "scoop bucket add main" }
         Should -Invoke -CommandName Invoke-CommandLine -Exactly 4 -ParameterFilter { $CommandLine -like "scoop install */*.json" }
     }
 
@@ -130,7 +144,7 @@ Describe "Install-Scoop" {
 
         Install-Scoop
 
-        Should -Invoke -CommandName Invoke-CommandLine -Exactly 8
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 9
         Should -Invoke -CommandName Import-ScoopFile -Exactly 1 -ParameterFilter { $ScoopFilePath -eq "scoopfile.json" }
     }
 
@@ -142,9 +156,7 @@ Describe "Install-Scoop" {
         Install-Scoop
         $config.scoop_ignore_scoopfile = $false
 
-        Should -Invoke -CommandName Invoke-CommandLine -Exactly 8
-        Should -Invoke -CommandName Invoke-CommandLine -Exactly 0 -ParameterFilter { $CommandLine -eq "scoop update" }
-        Should -Invoke -CommandName Invoke-CommandLine -Exactly 0 -ParameterFilter { $CommandLine -eq "scoop import scoopfile.json --reset" }
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 9
     }
 }
 
@@ -198,9 +210,22 @@ Describe "Install-Python" {
         
         Install-Python
         
-        Should -Invoke -CommandName Invoke-CommandLine -Exactly 1
-        Should -Invoke -CommandName Invoke-CommandLine -Exactly 1 -ParameterFilter { $CommandLine -like "scoop install */python311.json" }
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 2
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 1 -ParameterFilter { $CommandLine -eq "scoop bucket add versions" }
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 1 -ParameterFilter { $CommandLine -eq "scoop install python311" }
         Should -Invoke -CommandName Write-Output -Exactly 1 -ParameterFilter { $InputObject -eq "python311 not found. Try to install python311 via scoop ..." }
+    }
+
+    It "shall install python from URL when scoop_python_bucket_base_url is configured" {
+        Mock -CommandName Get-Command -MockWith { $null }
+
+        $config.scoop_python_bucket_base_url = "https://raw.githubusercontent.com/ScoopInstaller/Versions/master/bucket"
+        Install-Python
+        $config.scoop_python_bucket_base_url = ""
+
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 1
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 0 -ParameterFilter { $CommandLine -eq "scoop bucket add versions" }
+        Should -Invoke -CommandName Invoke-CommandLine -Exactly 1 -ParameterFilter { $CommandLine -like "scoop install */python311.json" }
     }
     
     It "shall not install python if python is available" {


### PR DESCRIPTION
Upstream 7zip manifest now has post_install scripts that reference local bucket files, breaking installs from raw URLs on fresh runners.

Default behavior now adds the main/versions bucket and installs by name. Repos that need the old URL-based approach can set scoop_default_bucket_base_url or scoop_python_bucket_base_url in bootstrap.json to restore legacy behavior.

Closes #55